### PR TITLE
v-for should have explicit keys

### DIFF
--- a/src/components/Root.vue
+++ b/src/components/Root.vue
@@ -1,6 +1,8 @@
 <template>
   <div v-editable="blok">
-    <component v-for="item in blok.body" :blok="item" :is="item.component"></component>
+  <template v-for="item in blok.body">
+    <component  :blok="item" :is="item.component"></component>
+  </template>
   </div>
 </template>
 


### PR DESCRIPTION
Component lists rendered with v-for should have explicit keys. See https://vuejs.org/guide/list.html#key for more info.